### PR TITLE
Fix error in HA logs due to unavailability of attached sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ cython_debug/
 
 # Built Visual Studio Code Extensions
 *.vsix
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1 (2023-06-10)
+
+Fix error in HA logs due to unavailability of attached temp / humidity sensors (state: `unkown`) [#4](https://github.com/Strixx76/mold_risk_index/issues/4)
+
 # 1.0.0 (2022-12-29)
 
 Initial release.

--- a/custom_components/mold_risk_index/manifest.json
+++ b/custom_components/mold_risk_index/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mold_risk_index",
   "name": "Mold Risk Index",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "documentation": "https://github.com/Strixx76/mold_risk_index",
   "issue_tracker": "https://github.com/Strixx76/mold_risk_index/issues",
   "codeowners": ["@Strixx76"],

--- a/custom_components/mold_risk_index/sensor.py
+++ b/custom_components/mold_risk_index/sensor.py
@@ -244,22 +244,13 @@ class MoldRiskLimitSensor(MoldRiskBaseSensor):
         self._mold_calc.async_event_receiver(event)
         
         if self._mold_calc.humidity_limit_level_1 != self._limit_level_1:
-            if self._mold_calc.humidity_limit_level_1 is None:
-                self._limit_level_1 = STATE_UNKNOWN
-            else: 
-                self._limit_level_1 = self._mold_calc.humidity_limit_level_1
+            self._limit_level_1 = self._mold_calc.humidity_limit_level_1
             updated = True
         if self._mold_calc.humidity_limit_level_2 != self._limit_level_2:
-            if self._mold_calc.humidity_limit_level_2 is None:
-                self._limit_level_2 = STATE_UNKNOWN
-            else: 
-                self._limit_level_2 = self._mold_calc.humidity_limit_level_2
+            self._limit_level_2 = self._mold_calc.humidity_limit_level_2
             updated = True
         if self._mold_calc.humidity_limit_level_3 != self._limit_level_3:
-            if self._mold_calc.humidity_limit_level_3 is None:
-                self._limit_level_3 = STATE_UNKNOWN
-            else: 
-                self._limit_level_3 = self._mold_calc.humidity_limit_level_3
+            self._limit_level_3 = self._mold_calc.humidity_limit_level_3
             updated = True
         
         if updated:
@@ -313,10 +304,7 @@ class MoldRiskIndexSensor(MoldRiskBaseSensor):
         """ Listen for sensor state changes. """
         self._mold_calc.async_event_receiver(event)
         if self._mold_calc.risk != self._risk:
-            if self._mold_calc.risk is None:
-                self._risk = STATE_UNKNOWN
-            else:
-                self._risk = self._mold_calc.risk
+            self._risk = self._mold_calc.risk
             self.async_write_ha_state()
     
     @property


### PR DESCRIPTION
Fix error in HA logs due to unavailability of attached temp / humidity sensors (state: `unkown`) [#4](https://github.com/Strixx76/mold_risk_index/issues/4)
