### PR TITLE
Fix incorrect risk calculation for Fahrenheit temperature sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+Fix incorrect risk calculation when the configured temperature sensor reports in Fahrenheit. The risk formulas are calibrated for Celsius input; Fahrenheit values are now converted before calculation. [#12](https://github.com/Strixx76/mold_risk_index/issues/12)
+
 # 1.1.0 (2023-11-06)
 
 Added translations for de, sk and sv

--- a/custom_components/mold_risk_index/sensor.py
+++ b/custom_components/mold_risk_index/sensor.py
@@ -16,11 +16,13 @@ from homeassistant.const import (
     PERCENTAGE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    UnitOfTemperature,
 )
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
     CONF_HUM_ID,
@@ -135,6 +137,14 @@ class MoldRiskCalculator:
                 new_state = None
 
         if entity == self._temp_entity_id:
+            if new_state is not None:
+                unit = state.attributes.get("unit_of_measurement")
+                if unit == UnitOfTemperature.FAHRENHEIT:
+                    new_state = TemperatureConverter.convert(
+                        new_state,
+                        UnitOfTemperature.FAHRENHEIT,
+                        UnitOfTemperature.CELSIUS,
+                    )
             if new_state == self.temperature:
                 return
             self.temperature = new_state


### PR DESCRIPTION
Fixes #12

## Problem

The risk formulas in `calc_limit_1`/`calc_limit_2`/`calc_limit_3` are calibrated for Celsius input — each checks `0 <= temp <= 50` and falls back to a limit of `100` for anything outside that range:

```python
def calc_limit_1(self, temp):
    if 0 <= temp <= 50:
        limit = round(20 * exp(-temp * 0.15) + 73)
        return max(min(100, limit), 72)
    else:
        return 100
```

`async_event_receiver` reads the input sensor's state with a plain `float(state.state)` and never checks its unit, so a Fahrenheit-reporting temperature sensor gets passed straight into these Celsius-calibrated formulas.

In practice this means: any time the configured temperature sensor reads above 50°F (i.e. almost all of spring through fall in most climates), the raw Fahrenheit number falls outside the `0–50` guard, the humidity limit is forced to `100` for all three risk levels, and the risk index becomes mathematically incapable of registering — no matter how high the actual humidity gets. Below 50°F, the formula still runs, but on the raw Fahrenheit value, producing limits calibrated for the wrong temperature.

Confirmed against a real attic sensor: 65°F / 77% RH (well inside the "risk of growth" zone on the accompanying isopleth chart) computed as **risk = 0** before this fix.

## Fix

Check the temperature entity's `unit_of_measurement` attribute, and convert Fahrenheit readings to Celsius (via Home Assistant's own `TemperatureConverter`) before they reach the risk calculation.

- Celsius-configured sensors are unaffected — the unit check simply won't match `UnitOfTemperature.FAHRENHEIT`, so there's no behavior change for existing users.
- No new config-flow option or migration needed; this is fully automatic based on the sensor's own reported unit.
- Verified the same 65°F / 77% RH reading now correctly computes as risk level 1 after conversion (65°F → 18.3°C, limit₁ = 74%).

## Changes

- `custom_components/mold_risk_index/sensor.py`: convert Fahrenheit temperature readings to Celsius in `async_event_receiver`
- `CHANGELOG.md`: add entry under `Unreleased`